### PR TITLE
Release v0.1.0-alpha

### DIFF
--- a/frontend-react/package.json
+++ b/frontend-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend-react",
-  "version": "0.1.0",
+  "version": "0.1.0-alpha",
   "private": true,
   "dependencies": {
     "@radix-ui/react-slot": "^1.2.3",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.1.0"
+version = "0.1.0-alpha"
 description = "A Tauri App"
 authors = ["you"]
 license = ""

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "PulsePrint",
-	"version": "0.1.0",
+	"version": "0.1.0-alpha",
 	"identifier": "com.pulseprint.desktop",
 	"build": {
 		"frontendDist": "../frontend-react/build",


### PR DESCRIPTION
## Summary

This PR merges the v0.1.0-alpha release branch back to main, completing the Git flow release process.

## Changes Made

- ✅ Updated version numbers to 0.1.0-alpha in all configuration files
- ✅ Built and released alpha binaries for macOS  
- ✅ Created GitHub release with release notes and artifacts
- ✅ Merged release branch back to develop

## Type of Change

- [x] 🚀 Release (version bump and release artifacts)

## Release Artifacts

- ✅ macOS .dmg installer: `PulsePrint_0.1.0-alpha_aarch64.dmg`
- ✅ GitHub release: https://github.com/voodu00/pulseprint-desktop-app/releases/tag/v0.1.0-alpha

## Git Flow Completion

This PR completes the proper Git flow release process:

1. ✅ Created `release/v0.1.0-alpha` branch from `develop`
2. ✅ Updated version numbers on release branch  
3. ✅ Built release artifacts
4. ✅ Created GitHub release from release branch
5. ✅ Merged release branch back to `develop` 
6. 🔄 **This PR**: Merge release branch to `main`

🚀 Release URL: https://github.com/voodu00/pulseprint-desktop-app/releases/tag/v0.1.0-alpha